### PR TITLE
The blueprint during install:addon requires that bower.json exists

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,5 @@ tests/
 .travis.yml
 .npmignore
 **/.gitkeep
-bower.json
 Brocfile.js
 testem.json


### PR DESCRIPTION
A fresh `ember install:addon ember-timetree` fails during the blueprint phase because we rely on the `bower.json` being in the packaged tarball to lookup the needed d3 version.

Please publish a new version after this has been merged.